### PR TITLE
[FEATURE] CU-863gxpx04 | CBD only plans not populating in eo lite

### DIFF
--- a/apps/eo_web/src/api/PrePlanTypes.ts
+++ b/apps/eo_web/src/api/PrePlanTypes.ts
@@ -2,6 +2,7 @@ export enum Maladies {
   Sleep = "Sleep",
   Pain = "Pain",
   Anxiety = "Anxiety",
+  Other = "Other",
 }
 
 export enum WorseSymptomsMomentEnum {
@@ -24,6 +25,7 @@ export enum TimeToUse {
   WorkDayBedtimes = "Workday Bedtimes",
   NonWorkDayBedtimes = "Non-Workday Bedtimes",
 }
+
 export type OpenToUseThcProducts = (typeof TimeToUse)[keyof typeof TimeToUse];
 
 export enum AvoidPresentationEnum {
@@ -41,6 +43,7 @@ export enum ThcProductPreferencesEnum {
   notPrefer = "I’d prefer to use non-THC (CBD/CBN/CBG) products only.",
   notSure = "I’m not sure.",
 }
+
 export type ThcProductPreferences =
   (typeof ThcProductPreferencesEnum)[keyof typeof ThcProductPreferencesEnum];
 

--- a/apps/eo_web/src/screens/PrePlanV2.tsx
+++ b/apps/eo_web/src/screens/PrePlanV2.tsx
@@ -40,12 +40,13 @@ export const PrePlanV2 = () => {
       if (
         data.malady === Maladies.Pain ||
         data.malady === Maladies.Anxiety ||
-        data.malady == Maladies.Sleep
+        data.malady === Maladies.Sleep ||
+        data.malady === Maladies.Other
       ) {
         // something jotform not return information, but re-fetching it will obtain it
         setJotformReturnedInformation(true);
       }
-      setCountFetching((state) => state++);
+      setCountFetching((state) => state + 1);
     },
     refetchInterval:
       jotformReturnedInformation || countFetching >= maxRetries ? false : 1500,
@@ -132,7 +133,10 @@ export const PrePlanV2 = () => {
     .filter((schedule) => !!schedule.type);
 
   const hasDataToShow =
-    (hasWorkdayTimeSelected() || hasNonWorkDayTimeSelected()) &&
+    (hasWorkdayTimeSelected() ||
+      jotformAnswers?.thc_type_preferences ===
+        ThcProductPreferencesEnum.notPrefer ||
+      hasNonWorkDayTimeSelected()) &&
     scheduleWorkDay.length &&
     scheduleNonWorkdayData.length;
 
@@ -294,10 +298,18 @@ export const PrePlanV2 = () => {
             <>
               {hasDataToShow ? (
                 <>
-                  {hasWorkdayTimeSelected() &&
-                    renderPlan("On Workday", scheduleWorkDay)}
+                  {hasWorkdayTimeSelected() ||
+                    (jotformAnswers?.thc_type_preferences ===
+                      ThcProductPreferencesEnum.notPrefer &&
+                      renderPlan(
+                        jotformAnswers?.thc_type_preferences !==
+                          ThcProductPreferencesEnum.notPrefer
+                          ? "On Workday"
+                          : "Daily Schedule",
+                        scheduleWorkDay,
+                      ))}
                   {hasNonWorkDayTimeSelected() &&
-                    renderPlan("On Non-Workdays", scheduleWorkDay)}
+                    renderPlan("On Non-Workdays", scheduleNonWorkdayData)}
                 </>
               ) : (
                 <div className="my-10">


### PR DESCRIPTION
feature: change header when thc preferences is not use cbd or thc for "Daily schedule" and also fix mas retries attemp

# Light It Pull Request Template ⚡⚡⚡

_Resolve_: [CBD only plans not populating in eo lite](https://app.clickup.com/t/863gxpx04)

## Description and Requires ⭐

feature: change header when thc preferences is not use cbd or thc for "Daily schedule" and also fix mas retries attemp
<img width="1512" alt="Screenshot 2023-06-08 at 08 57 00" src="https://github.com/Light-it-labs/eo_web/assets/117183993/64a891a2-fca9-43ca-b940-fc8d3a088647">

## Checklist ✅

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
